### PR TITLE
Update GitHub workflows to support Node.js versions 18.x, 20.x, and 2…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -31,7 +31,7 @@ jobs:
     - run: npm i --no-save @aws-sdk/client-dynamodb@^3 @aws-sdk/client-s3@^3 @aws-sdk/client-secrets-manager@^3 @aws-sdk/client-sts@^3 @aws-sdk/credential-providers@^3 @aws-sdk/lib-dynamodb@^3 @aws-sdk/lib-storage@^3 @aws-sdk/node-http-handler@^3
     - run: npm run compile --if-present
     - run: npm run coverage-all --if-present
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: code-coverage-${{ matrix.node-version }}
         path: coverage/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm i --no-save aws-sdk@^2


### PR DESCRIPTION
…2.x. Upgrade upload-artifact action to v4 and set npm publish workflow to use Node.js version 20.